### PR TITLE
Make chart compatible with k8s 1.16

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "jellyfin.fullname" . }}


### PR DESCRIPTION
[Kubernetes removed `apps/v1beta2` in 1.16.](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) `apps/v1` has around since at least 1.9, so it should be pretty safe to change.