### PR TITLE
Change rollout strategy to Recreate

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  strategy:
+    type: Recreate
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:


### PR DESCRIPTION
Jellyfin is a stateful application that can't handle multiple instances accessing the same database file. The default rollout strategy brings up a new pod before killing the old one. This creates a situation where the new pod is stuck in a CrashLoopBackoff because it can't acquire a lock on the database. Changing the rollout strategy to `Recreate` means that the old Jellyfin pod must die before the new Jellyfin pod can come up.

This *does* mean that rollouts will always have some downtime, but that was the reality of the situation anyways. This PR just makes that explicit. Once Jellyfin supports multiple instances then this could be changed back to the default value.