### PR TITLE
Update ingress to use networking.k8s.io/v1 api version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
-description: Jellyfin
+description: Jellyfin Media Server
 name: jellyfin
-version: 0.1.0
+version: 0.2.0
+type: application

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This is a helm chart for [Jellyfin](https://github.com/jellyfin/jellyfin/)
 
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3+
+
 ## TL;DR;
 
 ```shell
@@ -15,7 +20,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 git clone https://github.com/brianmcarey/jellyfin-helm.git
-helm install --name my-release ./jellyfin-helm
+helm install  my-release ./jellyfin-helm
 ```
 
 ## Uninstalling the Chart
@@ -23,7 +28,7 @@ helm install --name my-release ./jellyfin-helm
 To uninstall/delete the `my-release` deployment:
 
 ```console
-helm delete my-release --purge
+helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "jellyfin.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -15,6 +15,11 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -30,9 +35,12 @@ spec:
     - host: {{ . | quote }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          - pathType: Prefix
+            path: {{ $ingressPath }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress will no longer be served in v1.22.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122