### PR TITLE
media: Do not attach volume when disabled

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -41,8 +41,10 @@ spec:
             {{- if .Values.persistence.config.subPath }}
               subPath: {{ .Values.persistence.config.subPath }}
             {{- end }}
+            {{- if .Values.persistence.media.enabled }}
             - mountPath: /media
               name: media
+            {{- end }}
             {{- if .Values.persistence.media.subPath }}
               subPath: {{ .Values.persistence.media.subPath }}
             {{- end }}
@@ -64,12 +66,10 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
-      - name: media
       {{- if .Values.persistence.media.enabled }}
+      - name: media
         persistentVolumeClaim:
           claimName: {{ if .Values.persistence.media.existingClaim }}{{ .Values.persistence.media.existingClaim }}{{- else }}{{ template "jellyfin.fullname" . }}-media{{- end }}
-      {{- else }}
-        emptyDir: {}
       {{- end }}
       {{- range .Values.persistence.extraExistingClaimMounts }}
       - name: {{ .name }}


### PR DESCRIPTION
When the volume is attached as emptyDir, it will be a local volume
resulting in inability to drain a node because of existing local volumes
in the pod. This changes the semantics such that /media is never mounted
as a volume if it is not specifically enabled, allowing jellyfin to be
re-located to other nodes in the cluster