### PR TITLE
Add configuration to allow for enabling DLNA

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 appVersion: "1.0"
 description: Jellyfin Media Server
 name: jellyfin
-version: 0.2.0
+version: 0.3.0
 type: application

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `image.repository`         | Image repository | `jellyfin/jellyfin` |
 | `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/jellyfin/jellyfin/tags/).| `latest`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
+| `enableDLNA`		  | Enable DLNA for jellyfin | `false` |
 | `Service.type`          | Kubernetes service type for the jellyfin GUI | `ClusterIP` |
 | `Service.port`          | Kubernetes port where the jellyfin GUI is exposed| `8096` |
 | `Service.annotations`   | Service annotations for the jellyfin GUI | `{}` |

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Sentry chart and their default values.
+The following tables lists the configurable parameters of the Jellyfin chart and their default values.
 
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
-| `image.repository`         | Image repository | `jellyfin/jellyfin` |
+| `image.repository`         | Image repository | `docker.io/jellyfin/jellyfin` |
 | `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/jellyfin/jellyfin/tags/).| `latest`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `enableDLNA`		  | Enable DLNA for jellyfin | `false` |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app.kubernetes.io/name: {{ include "jellyfin.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+    {{- if .Values.enableDLNA }}
+      hostNetwork: true
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -29,6 +32,12 @@ spec:
             - name: http
               containerPort: 8096
               protocol: TCP
+          {{ if .Values.enableDLNA }}
+            - name: dlna
+              containerPort: 1900
+              hostPort: 1900
+              protocol: UDP
+          {{- end }}
           livenessProbe:
             tcpSocket:
               port: http

--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: jellyfin/jellyfin
+  repository: docker.io/jellyfin/jellyfin
   tag: latest
   pullPolicy: IfNotPresent
 

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,12 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+# Setting this to true enables DLNA which requires the pod to be attached to the
+# host network in order to be useful - this can break things like ingress to the service
+# https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#hosts-namespaces
+# https://jellyfin.org/docs/general/networking/dlna.html
+enableDLNA: false
+
 service:
   type: ClusterIP
   port: 8096


### PR DESCRIPTION
This requires allowing the pod to use the host's network namespace
as DLNA is broadcast on the local subnet.

Closes https://github.com/brianmcarey/jellyfin-helm/issues/6